### PR TITLE
chore: base logger setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 package-lock.json
 .env
+/logs

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
+# Node
 /node_modules
 package-lock.json
+
+# Environment
 .env
+
+# Logs
 /logs

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Temp files
+.DS_Store
+Thumbs.db
+
 # Node
 /node_modules
 package-lock.json

--- a/logger.js
+++ b/logger.js
@@ -1,0 +1,23 @@
+const { createLogger, format, transports } = require('winston');
+
+// Transports
+const errorFileTransport = new transports.File({
+  format: format.json(),
+  filename: 'logs/error.log',
+  level: 'error',
+});
+const combinedConsoleTransport = new transports.Console({
+  format: format.simple(),
+});
+
+// Always bulk error logs to file.
+const logger = createLogger({
+  transports: [errorFileTransport],
+});
+
+// Log to console if not in production.
+if (process.env.NODE_ENV !== 'production') {
+  logger.add(combinedConsoleTransport);
+}
+
+module.exports = logger;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/pastranaserra/ecomm#readme",
   "dependencies": {
-    "dotenv": "^16.0.0"
+    "dotenv": "^16.0.0",
+    "winston": "^3.7.2"
   }
 }


### PR DESCRIPTION
## Details

Use `winston` to standardize the logging system.

- The logger will always output the errors to a file.
- The logger will output any log to the console when not in PROD env.