### PR TITLE
refactor: split middlewares implementation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,7 @@
     "ecmaVersion": "latest"
   },
   "rules": {
+    "linebreak-style": "off",
     "implicit-arrow-linebreak": "off"
   }
 }

--- a/server/middlewares/error.js
+++ b/server/middlewares/error.js
@@ -1,20 +1,5 @@
-const morgan = require('morgan');
-const { v4: uuid } = require('uuid');
-
-const logger = require('../logger');
-
-const { logErrorOnRequest } = require('./logger');
-
-const reqIdSetter = (req, _, next) => {
-  req.id = uuid();
-  next();
-};
-
-morgan.token('id', (req) => req.id);
-const reqLogger = morgan(
-  ':remote-addr [:date[iso]] :id - ":method :url" - :status',
-  { stream: { write: (message) => logger.info(message.trim()) } },
-);
+const logger = require('../../logger');
+const { logErrorOnRequest } = require('../logger');
 
 const notFoundMiddleware = (_, __, next) => {
   next({ statusCode: 404, message: 'Not Found' });
@@ -45,4 +30,4 @@ const errorHandlers = [
   errorHandlerMiddleware,
 ];
 
-module.exports = { reqIdSetter, reqLogger, errorHandlers };
+module.exports = errorHandlers;

--- a/server/middlewares/index.js
+++ b/server/middlewares/index.js
@@ -1,0 +1,9 @@
+const reqIdSetter = require('./req-id-setter');
+const reqLogger = require('./logger');
+const errorHandlers = require('./error');
+
+module.exports = {
+  reqIdSetter,
+  reqLogger,
+  errorHandlers,
+};

--- a/server/middlewares/logger.js
+++ b/server/middlewares/logger.js
@@ -1,0 +1,11 @@
+const morgan = require('morgan');
+
+const logger = require('../../logger');
+
+morgan.token('id', (req) => req.id);
+const reqLogger = morgan(
+  ':remote-addr [:date[iso]] :id - ":method :url" - :status',
+  { stream: { write: (message) => logger.info(message.trim()) } },
+);
+
+module.exports = reqLogger;

--- a/server/middlewares/req-id-setter.js
+++ b/server/middlewares/req-id-setter.js
@@ -1,0 +1,8 @@
+const { v4: uuid } = require('uuid');
+
+const reqIdSetter = (req, _, next) => {
+  req.id = uuid();
+  next();
+};
+
+module.exports = reqIdSetter;


### PR DESCRIPTION
## Details

- Use a single file for each middleware implementation
- Add missing lint to ignore error related to line breaks