### PR TITLE
chore: create admin checker middleware

### DIFF
--- a/server/api/v1/auth/middlewares.js
+++ b/server/api/v1/auth/middlewares.js
@@ -3,7 +3,12 @@ const { verify } = require('jsonwebtoken');
 const {
   jwt: { secret },
 } = require('../../../../config');
-const { UnauthorizedErrorResponse } = require('../../../responses');
+const logger = require('../../../../logger');
+const {
+  UnauthorizedErrorResponse,
+  ForbiddenErrorResponse,
+  InternalServerErrorResponse,
+} = require('../../../responses');
 const { User } = require('../users');
 
 const bearerPrefix = 'Bearer ';
@@ -22,6 +27,24 @@ exports.me = async (req, _, next) => {
     const me = await User.findById(id);
     if (!me) return next(UnauthorizedErrorResponse());
     req.me = me;
+    return next();
+  } catch (err) {
+    return next(err);
+  }
+};
+
+exports.isAdmin = async (req, _, next) => {
+  try {
+    if (!req.me) {
+      logger.error(
+        `
+Implementation error:
+The 'me' middleware must be used before the 'isAdmin' middleware.
+`,
+      );
+      return next(InternalServerErrorResponse());
+    }
+    if (!req.me.isAdmin) return next(ForbiddenErrorResponse());
     return next();
   } catch (err) {
     return next(err);


### PR DESCRIPTION
## Details

Create middleware to check if the authenticated user is an admin.
This middleware requires the previous use of the `me` middleware.