### PR TITLE
fix: use proper field name for status

### DIFF
--- a/server/responses.js
+++ b/server/responses.js
@@ -1,5 +1,5 @@
 exports.BadRequestErrorResponse = (message = 'Bad Request') => ({
-  status: 400,
+  statusCode: 400,
   message,
 });
 


### PR DESCRIPTION
## Details

Use `statusCode` for the response status field.